### PR TITLE
^ updated dx record display bug fix

### DIFF
--- a/uScript/lib_DX10.usc
+++ b/uScript/lib_DX10.usc
@@ -1200,10 +1200,6 @@ updateClientdx = $dbreaduid(dx_rec, 2, clientid, dx10_dstlist)
 
 'Void it off as changed
 void_reason = "This record was changed by staff id " + staffid + ". "
-if c_dx10_snapid dp then
-   void_reason += "Please see snap id: " + c_dx10_snapid + " for the updates."
-endif
-'void_code = "9010"
 
 voiddxdoc(c.dx10.snapid, void_reason, void_code, c_dx10_snapid)
 


### PR DESCRIPTION
   : Issue : the comments section of the voided dx record
      resulting from an update was not displaying correctly
      The update process was inserting the NEW snapshot id
      into the void reason comments which can contain unescaped
      html characters causing the browser to display incorrectly
   : fix :
      don't insert the snap id in the reason for void comments
modified:   lib_DX10.usc
